### PR TITLE
Add console option to publish documents to GitHub

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,6 +12,8 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <maven.compiler.source>11</maven.compiler.source>
+    <maven.compiler.target>11</maven.compiler.target>
   </properties>
 
   <dependencies>

--- a/src/main/java/cafe/dev/test_git/App.java
+++ b/src/main/java/cafe/dev/test_git/App.java
@@ -1,16 +1,16 @@
 package cafe.dev.test_git;
 
-/**
- * Hello world!
- *
- */
-public class App 
-{
-    public static void main( String[] args )
-    {
-        System.out.println( "Hello World!!" );
+import java.util.Scanner;
+
+public class App {
+    public static void main(String[] args) {
+        DocumentRepository repository = new DocumentRepository();
+        DocumentService service = new DocumentService(repository);
+        DocumentMarkdownFormatter formatter = new DocumentMarkdownFormatter();
+        GitHubPublisher publisher = new GitHubPublisher();
+        try (Scanner scanner = new Scanner(System.in)) {
+            DocumentConsoleUI ui = new DocumentConsoleUI(service, formatter, publisher, scanner);
+            ui.run();
+        }
     }
-   
 }
-
-

--- a/src/main/java/cafe/dev/test_git/Document.java
+++ b/src/main/java/cafe/dev/test_git/Document.java
@@ -1,0 +1,100 @@
+package cafe.dev.test_git;
+
+import java.time.LocalDateTime;
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.Objects;
+import java.util.Set;
+
+/**
+ * Represents a document that can be stored and managed by the application.
+ */
+public class Document {
+    private final String id;
+    private String title;
+    private String content;
+    private final LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+    private final Set<String> tags = new LinkedHashSet<>();
+
+    public Document(String id, String title, String content, Set<String> tags) {
+        if (id == null || id.isBlank()) {
+            throw new IllegalArgumentException("Document id must not be blank");
+        }
+        if (title == null || title.isBlank()) {
+            throw new IllegalArgumentException("Document title must not be blank");
+        }
+        this.id = id.trim();
+        this.title = title.trim();
+        this.content = content == null ? "" : content;
+        this.createdAt = LocalDateTime.now();
+        this.updatedAt = this.createdAt;
+        if (tags != null) {
+            tags.stream()
+                .filter(Objects::nonNull)
+                .map(String::trim)
+                .filter(tag -> !tag.isEmpty())
+                .forEach(this.tags::add);
+        }
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public void setTitle(String title) {
+        if (title == null || title.isBlank()) {
+            throw new IllegalArgumentException("Document title must not be blank");
+        }
+        this.title = title.trim();
+        this.updatedAt = LocalDateTime.now();
+    }
+
+    public String getContent() {
+        return content;
+    }
+
+    public void setContent(String content) {
+        this.content = content == null ? "" : content;
+        this.updatedAt = LocalDateTime.now();
+    }
+
+    public Set<String> getTags() {
+        return Collections.unmodifiableSet(tags);
+    }
+
+    public void setTags(Set<String> updatedTags) {
+        this.tags.clear();
+        if (updatedTags != null) {
+            updatedTags.stream()
+                .filter(Objects::nonNull)
+                .map(String::trim)
+                .filter(tag -> !tag.isEmpty())
+                .forEach(this.tags::add);
+        }
+        this.updatedAt = LocalDateTime.now();
+    }
+
+    public LocalDateTime getCreatedAt() {
+        return createdAt;
+    }
+
+    public LocalDateTime getUpdatedAt() {
+        return updatedAt;
+    }
+
+    @Override
+    public String toString() {
+        return "Document{" +
+            "id='" + id + '\'' +
+            ", title='" + title + '\'' +
+            ", tags=" + tags +
+            ", createdAt=" + createdAt +
+            ", updatedAt=" + updatedAt +
+            '}';
+    }
+}

--- a/src/main/java/cafe/dev/test_git/DocumentConsoleUI.java
+++ b/src/main/java/cafe/dev/test_git/DocumentConsoleUI.java
@@ -1,0 +1,294 @@
+package cafe.dev.test_git;
+
+import java.io.IOException;
+import java.time.format.DateTimeFormatter;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Scanner;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * Simple console interface for interacting with the document service.
+ */
+public class DocumentConsoleUI {
+    private static final DateTimeFormatter DATE_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm");
+
+    private final DocumentService service;
+    private final DocumentMarkdownFormatter formatter;
+    private final GitHubPublisher publisher;
+    private final Scanner scanner;
+
+    public DocumentConsoleUI(DocumentService service, DocumentMarkdownFormatter formatter, GitHubPublisher publisher,
+        Scanner scanner) {
+        this.service = service;
+        this.formatter = formatter;
+        this.publisher = publisher;
+        this.scanner = scanner;
+    }
+
+    public void run() {
+        boolean running = true;
+        while (running) {
+            printMenu();
+            String choice = prompt("번호를 선택하세요");
+            switch (choice) {
+                case "1":
+                    addDocument();
+                    break;
+                case "2":
+                    updateDocumentTitle();
+                    break;
+                case "3":
+                    updateDocumentContent();
+                    break;
+                case "4":
+                    updateDocumentTags();
+                    break;
+                case "5":
+                    deleteDocument();
+                    break;
+                case "6":
+                    searchByKeyword();
+                    break;
+                case "7":
+                    filterByTag();
+                    break;
+                case "8":
+                    listDocuments();
+                    break;
+                case "9":
+                    showSummary();
+                    break;
+                case "10":
+                    publishToGitHub();
+                    break;
+                case "0":
+                    running = false;
+                    break;
+                default:
+                    System.out.println("올바르지 않은 입력입니다. 다시 시도하세요.");
+            }
+        }
+        System.out.println("프로그램을 종료합니다.");
+    }
+
+    private void printMenu() {
+        System.out.println();
+        System.out.println("==== 문서 관리 프로그램 ====");
+        System.out.println("1. 문서 추가");
+        System.out.println("2. 문서 제목 수정");
+        System.out.println("3. 문서 내용 수정");
+        System.out.println("4. 문서 태그 수정");
+        System.out.println("5. 문서 삭제");
+        System.out.println("6. 키워드로 검색");
+        System.out.println("7. 태그로 필터링");
+        System.out.println("8. 전체 문서 목록");
+        System.out.println("9. 문서 통계 보기");
+        System.out.println("10. 깃허브에 문서 등록");
+        System.out.println("0. 종료");
+    }
+
+    private void addDocument() {
+        try {
+            String id = prompt("문서 ID");
+            String title = prompt("제목");
+            String content = promptMultiline("내용 (빈 줄 입력 시 종료)");
+            Set<String> tags = parseTags(prompt("태그 (쉼표로 구분, 생략 가능)"));
+            service.create(id, title, content, tags);
+            System.out.println("문서가 저장되었습니다.");
+        } catch (IllegalArgumentException ex) {
+            System.out.println("문서를 추가하지 못했습니다: " + ex.getMessage());
+        }
+    }
+
+    private void updateDocumentTitle() {
+        String id = prompt("수정할 문서 ID");
+        String newTitle = prompt("새 제목");
+        if (service.updateTitle(id, newTitle).isPresent()) {
+            System.out.println("제목이 수정되었습니다.");
+        } else {
+            System.out.println("해당 ID의 문서를 찾을 수 없습니다.");
+        }
+    }
+
+    private void updateDocumentContent() {
+        String id = prompt("수정할 문서 ID");
+        String content = promptMultiline("새 내용 (빈 줄 입력 시 종료)");
+        if (service.updateContent(id, content).isPresent()) {
+            System.out.println("내용이 수정되었습니다.");
+        } else {
+            System.out.println("해당 ID의 문서를 찾을 수 없습니다.");
+        }
+    }
+
+    private void updateDocumentTags() {
+        String id = prompt("수정할 문서 ID");
+        Set<String> tags = parseTags(prompt("새 태그 (쉼표로 구분)"));
+        if (service.updateTags(id, tags).isPresent()) {
+            System.out.println("태그가 수정되었습니다.");
+        } else {
+            System.out.println("해당 ID의 문서를 찾을 수 없습니다.");
+        }
+    }
+
+    private void deleteDocument() {
+        String id = prompt("삭제할 문서 ID");
+        if (service.remove(id).isPresent()) {
+            System.out.println("문서가 삭제되었습니다.");
+        } else {
+            System.out.println("해당 ID의 문서를 찾을 수 없습니다.");
+        }
+    }
+
+    private void searchByKeyword() {
+        String keyword = prompt("검색할 키워드");
+        List<Document> results = service.searchByKeyword(keyword);
+        if (results.isEmpty()) {
+            System.out.println("검색 결과가 없습니다.");
+        } else {
+            System.out.println(results.size() + "개의 문서를 찾았습니다.");
+            results.forEach(this::printDocumentDetail);
+        }
+    }
+
+    private void filterByTag() {
+        String tag = prompt("필터링할 태그");
+        List<Document> results = service.filterByTag(tag);
+        if (results.isEmpty()) {
+            System.out.println("해당 태그를 가진 문서가 없습니다.");
+        } else {
+            System.out.println(results.size() + "개의 문서를 찾았습니다.");
+            results.forEach(this::printDocumentDetail);
+        }
+    }
+
+    private void listDocuments() {
+        List<Document> documents = service.listAll();
+        if (documents.isEmpty()) {
+            System.out.println("등록된 문서가 없습니다.");
+        } else {
+            documents.forEach(this::printDocumentDetail);
+        }
+    }
+
+    private void showSummary() {
+        int total = service.count();
+        System.out.println("총 문서 수: " + total);
+        if (total == 0) {
+            System.out.println("등록된 문서 ID: (없음)");
+            return;
+        }
+        String joinedIds = service.listAll().stream()
+            .map(Document::getId)
+            .collect(Collectors.joining(", "));
+        System.out.println("등록된 문서 ID: " + joinedIds);
+    }
+
+    private void publishToGitHub() {
+        String id = prompt("등록할 문서 ID");
+        Document document = service.findById(id).orElse(null);
+        if (document == null) {
+            System.out.println("해당 ID의 문서를 찾을 수 없습니다.");
+            return;
+        }
+
+        String owner = prompt("GitHub 사용자/조직 이름");
+        if (owner.isBlank()) {
+            System.out.println("사용자 또는 조직 이름을 입력해야 합니다.");
+            return;
+        }
+        String repository = prompt("레포지토리 이름");
+        if (repository.isBlank()) {
+            System.out.println("레포지토리 이름을 입력해야 합니다.");
+            return;
+        }
+        String branch = prompt("브랜치 (엔터 시 기본 브랜치 사용)");
+        if (branch.isBlank()) {
+            branch = null;
+        }
+        String defaultPath = "docs/" + document.getId() + ".md";
+        String path = prompt("저장할 경로 (예: " + defaultPath + ")");
+        if (path.isBlank()) {
+            path = defaultPath;
+        }
+        String commitMessage = prompt("커밋 메시지 (엔터 시 자동 생성)");
+        if (commitMessage.isBlank()) {
+            commitMessage = "Add document " + document.getTitle();
+        }
+        String token = prompt("개인 액세스 토큰");
+        if (token.isBlank()) {
+            System.out.println("개인 액세스 토큰을 입력해야 합니다.");
+            return;
+        }
+
+        GitHubPublisher.PublishRequest request = new GitHubPublisher.PublishRequest(owner, repository, branch, path, token,
+            commitMessage);
+
+        try {
+            GitHubPublisher.PublishResult result = publisher.publish(formatter.toMarkdown(document), request);
+            if (result.isSuccess()) {
+                String message = result.isUpdated()
+                    ? "기존 문서를 업데이트했습니다."
+                    : "새 문서를 등록했습니다.";
+                System.out.println("GitHub에 성공적으로 업로드되었습니다: " + message);
+                System.out.println("HTTP 상태 코드: " + result.getStatusCode());
+            } else {
+                System.out.println("업로드에 실패했습니다. 상태 코드: " + result.getStatusCode());
+                if (result.getErrorMessage() != null && !result.getErrorMessage().isBlank()) {
+                    System.out.println("응답 메시지: " + result.getErrorMessage());
+                }
+            }
+        } catch (InterruptedException ex) {
+            Thread.currentThread().interrupt();
+            System.out.println("GitHub 통신이 중단되었습니다.");
+        } catch (IOException ex) {
+            System.out.println("GitHub에 연결하지 못했습니다: " + ex.getMessage());
+        }
+    }
+
+    private void printDocumentDetail(Document document) {
+        String tags = document.getTags().isEmpty()
+            ? "(태그 없음)"
+            : String.join(", ", document.getTags());
+        System.out.println("-----------------------------");
+        System.out.println("ID: " + document.getId());
+        System.out.println("제목: " + document.getTitle());
+        System.out.println("태그: " + tags);
+        System.out.println("생성일: " + document.getCreatedAt().format(DATE_FORMATTER));
+        System.out.println("수정일: " + document.getUpdatedAt().format(DATE_FORMATTER));
+        System.out.println("내용:\n" + document.getContent());
+    }
+
+    private String prompt(String message) {
+        System.out.print(message + ": ");
+        return scanner.nextLine().trim();
+    }
+
+    private String promptMultiline(String message) {
+        System.out.println(message);
+        StringBuilder builder = new StringBuilder();
+        while (true) {
+            String line = scanner.nextLine();
+            if (line == null || line.isBlank()) {
+                break;
+            }
+            builder.append(line).append(System.lineSeparator());
+        }
+        return builder.toString().trim();
+    }
+
+    private Set<String> parseTags(String rawTags) {
+        if (rawTags == null || rawTags.isBlank()) {
+            return Set.of();
+        }
+        Set<String> tags = new LinkedHashSet<>();
+        for (String tag : rawTags.split(",")) {
+            String normalized = tag.trim();
+            if (!normalized.isEmpty()) {
+                tags.add(normalized);
+            }
+        }
+        return tags;
+    }
+}

--- a/src/main/java/cafe/dev/test_git/DocumentMarkdownFormatter.java
+++ b/src/main/java/cafe/dev/test_git/DocumentMarkdownFormatter.java
@@ -1,0 +1,38 @@
+package cafe.dev.test_git;
+
+import java.time.format.DateTimeFormatter;
+
+/**
+ * Converts {@link Document} instances into Markdown representations that can be
+ * published to services such as GitHub.
+ */
+public class DocumentMarkdownFormatter {
+    private static final DateTimeFormatter DATE_FORMATTER = DateTimeFormatter.ISO_LOCAL_DATE_TIME;
+
+    /**
+     * Builds a Markdown string containing the document's metadata and body.
+     *
+     * @param document the document to format
+     * @return a Markdown representation
+     */
+    public String toMarkdown(Document document) {
+        StringBuilder builder = new StringBuilder();
+        builder.append("# ").append(document.getTitle()).append('\n');
+        builder.append("\n");
+        builder.append("- ID: ").append(document.getId()).append('\n');
+        builder.append("- 생성일: ")
+            .append(document.getCreatedAt().format(DATE_FORMATTER))
+            .append('\n');
+        builder.append("- 수정일: ")
+            .append(document.getUpdatedAt().format(DATE_FORMATTER))
+            .append('\n');
+        if (!document.getTags().isEmpty()) {
+            builder.append("- 태그: ");
+            builder.append(String.join(", ", document.getTags()));
+            builder.append('\n');
+        }
+        builder.append("\n");
+        builder.append(document.getContent()).append('\n');
+        return builder.toString();
+    }
+}

--- a/src/main/java/cafe/dev/test_git/DocumentRepository.java
+++ b/src/main/java/cafe/dev/test_git/DocumentRepository.java
@@ -1,0 +1,47 @@
+package cafe.dev.test_git;
+
+import java.util.Collection;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Simple in-memory store for documents.
+ */
+public class DocumentRepository {
+    private final Map<String, Document> documents = new ConcurrentHashMap<>();
+
+    public Optional<Document> findById(String id) {
+        if (id == null) {
+            return Optional.empty();
+        }
+        return Optional.ofNullable(documents.get(id.trim()));
+    }
+
+    public Collection<Document> findAll() {
+        return documents.values();
+    }
+
+    public Document save(Document document) {
+        documents.put(document.getId(), document);
+        return document;
+    }
+
+    public Optional<Document> delete(String id) {
+        if (id == null) {
+            return Optional.empty();
+        }
+        return Optional.ofNullable(documents.remove(id.trim()));
+    }
+
+    public boolean exists(String id) {
+        if (id == null) {
+            return false;
+        }
+        return documents.containsKey(id.trim());
+    }
+
+    public int count() {
+        return documents.size();
+    }
+}

--- a/src/main/java/cafe/dev/test_git/DocumentService.java
+++ b/src/main/java/cafe/dev/test_git/DocumentService.java
@@ -1,0 +1,92 @@
+package cafe.dev.test_git;
+
+import java.util.Comparator;
+import java.util.List;
+import java.util.Locale;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * Provides high level operations for managing documents.
+ */
+public class DocumentService {
+    private final DocumentRepository repository;
+
+    public DocumentService(DocumentRepository repository) {
+        this.repository = repository;
+    }
+
+    public Document create(String id, String title, String content, Set<String> tags) {
+        if (repository.exists(id)) {
+            throw new IllegalArgumentException("Document with id '" + id + "' already exists");
+        }
+        Document document = new Document(id, title, content, tags);
+        repository.save(document);
+        return document;
+    }
+
+    public Optional<Document> updateContent(String id, String newContent) {
+        return repository.findById(id).map(document -> {
+            document.setContent(newContent);
+            return document;
+        });
+    }
+
+    public Optional<Document> updateTitle(String id, String title) {
+        return repository.findById(id).map(document -> {
+            document.setTitle(title);
+            return document;
+        });
+    }
+
+    public Optional<Document> updateTags(String id, Set<String> tags) {
+        return repository.findById(id).map(document -> {
+            document.setTags(tags);
+            return document;
+        });
+    }
+
+    public Optional<Document> remove(String id) {
+        return repository.delete(id);
+    }
+
+    public Optional<Document> findById(String id) {
+        return repository.findById(id);
+    }
+
+    public List<Document> listAll() {
+        return repository.findAll().stream()
+            .sorted(Comparator.comparing(Document::getCreatedAt))
+            .collect(Collectors.toList());
+    }
+
+    public List<Document> searchByKeyword(String keyword) {
+        if (keyword == null || keyword.isBlank()) {
+            return List.of();
+        }
+        String lowered = keyword.toLowerCase(Locale.ROOT);
+        return repository.findAll().stream()
+            .filter(doc -> doc.getTitle().toLowerCase(Locale.ROOT).contains(lowered)
+                || doc.getContent().toLowerCase(Locale.ROOT).contains(lowered))
+            .sorted(Comparator.comparing(Document::getTitle, String.CASE_INSENSITIVE_ORDER))
+            .collect(Collectors.toList());
+    }
+
+    public List<Document> filterByTag(String tag) {
+        if (tag == null || tag.isBlank()) {
+            return List.of();
+        }
+        String normalized = tag.trim().toLowerCase(Locale.ROOT);
+        return repository.findAll().stream()
+            .filter(doc -> doc.getTags().stream()
+                .map(existingTag -> existingTag.toLowerCase(Locale.ROOT))
+                .anyMatch(existing -> existing.equals(normalized)))
+            .sorted(Comparator.comparing(Document::getTitle, String.CASE_INSENSITIVE_ORDER))
+            .collect(Collectors.toList());
+    }
+
+    public int count() {
+        return repository.count();
+    }
+}

--- a/src/main/java/cafe/dev/test_git/GitHubPublisher.java
+++ b/src/main/java/cafe/dev/test_git/GitHubPublisher.java
@@ -1,0 +1,210 @@
+package cafe.dev.test_git;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.URLEncoder;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.Optional;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Publishes rendered documents to a GitHub repository using the REST API.
+ */
+public class GitHubPublisher {
+    private static final String API_BASE = "https://api.github.com";
+    private static final Pattern SHA_PATTERN = Pattern.compile("\"sha\"\\s*:\\s*\"([0-9a-fA-F]{40})\"");
+
+    private final HttpClient httpClient;
+
+    public GitHubPublisher() {
+        this(HttpClient.newHttpClient());
+    }
+
+    public GitHubPublisher(HttpClient httpClient) {
+        this.httpClient = httpClient;
+    }
+
+    /**
+     * Publishes the given markdown content to GitHub.
+     *
+     * @param markdown the document body to publish
+     * @param request  publishing options
+     * @return a {@link PublishResult} describing the outcome
+     * @throws IOException          when network errors occur
+     * @throws InterruptedException when the thread is interrupted
+     */
+    public PublishResult publish(String markdown, PublishRequest request) throws IOException, InterruptedException {
+        String encodedPath = encodePath(request.getPath());
+        String targetUrl = API_BASE + "/repos/" + encodeSegment(request.getOwner()) + "/"
+            + encodeSegment(request.getRepository()) + "/contents/" + encodedPath;
+
+        Optional<String> existingSha = fetchExistingSha(targetUrl, request);
+
+        String payload = buildPayload(markdown, request, existingSha);
+        HttpRequest httpRequest = HttpRequest.newBuilder(URI.create(targetUrl))
+            .header("Authorization", "Bearer " + request.getToken())
+            .header("Accept", "application/vnd.github+json")
+            .PUT(HttpRequest.BodyPublishers.ofString(payload))
+            .build();
+
+        HttpResponse<String> response = httpClient.send(httpRequest, HttpResponse.BodyHandlers.ofString());
+
+        if (response.statusCode() >= 200 && response.statusCode() < 300) {
+            return PublishResult.success(existingSha.isPresent(), response.statusCode());
+        }
+
+        return PublishResult.failure(response.statusCode(), response.body());
+    }
+
+    private Optional<String> fetchExistingSha(String targetUrl, PublishRequest request) throws IOException, InterruptedException {
+        String urlWithBranch = request.getBranch() == null
+            ? targetUrl
+            : targetUrl + "?ref=" + URLEncoder.encode(request.getBranch(), StandardCharsets.UTF_8);
+        HttpRequest.Builder builder = HttpRequest.newBuilder(URI.create(urlWithBranch))
+            .header("Authorization", "Bearer " + request.getToken())
+            .header("Accept", "application/vnd.github+json")
+            .GET();
+
+        HttpResponse<String> response = httpClient.send(builder.build(), HttpResponse.BodyHandlers.ofString());
+        if (response.statusCode() == 200) {
+            Matcher matcher = SHA_PATTERN.matcher(response.body());
+            if (matcher.find()) {
+                return Optional.ofNullable(matcher.group(1));
+            }
+        }
+        return Optional.empty();
+    }
+
+    private String buildPayload(String markdown, PublishRequest request, Optional<String> existingSha) {
+        StringBuilder builder = new StringBuilder();
+        builder.append('{');
+        builder.append("\"message\":\"").append(escapeJson(request.getCommitMessage())).append("\"");
+        builder.append(',');
+        builder.append("\"content\":\"")
+            .append(Base64.getEncoder().encodeToString(markdown.getBytes(StandardCharsets.UTF_8)))
+            .append("\"");
+        if (request.getBranch() != null && !request.getBranch().isBlank()) {
+            builder.append(',');
+            builder.append("\"branch\":\"")
+                .append(escapeJson(request.getBranch()))
+                .append("\"");
+        }
+        existingSha.ifPresent(sha -> {
+            builder.append(',');
+            builder.append("\"sha\":\"").append(sha).append("\"");
+        });
+        builder.append('}');
+        return builder.toString();
+    }
+
+    private String encodePath(String path) {
+        String[] segments = path.split("/");
+        StringBuilder builder = new StringBuilder();
+        for (int i = 0; i < segments.length; i++) {
+            if (i > 0) {
+                builder.append('/');
+            }
+            builder.append(encodeSegment(segments[i]));
+        }
+        return builder.toString();
+    }
+
+    private String encodeSegment(String value) {
+        return URLEncoder.encode(value, StandardCharsets.UTF_8);
+    }
+
+    private String escapeJson(String value) {
+        return value.replace("\\", "\\\\").replace("\"", "\\\"");
+    }
+
+    /**
+     * Parameters describing a GitHub publishing request.
+     */
+    public static class PublishRequest {
+        private final String owner;
+        private final String repository;
+        private final String branch;
+        private final String path;
+        private final String token;
+        private final String commitMessage;
+
+        public PublishRequest(String owner, String repository, String branch, String path, String token, String commitMessage) {
+            this.owner = owner;
+            this.repository = repository;
+            this.branch = (branch == null || branch.isBlank()) ? null : branch;
+            this.path = path;
+            this.token = token;
+            this.commitMessage = commitMessage;
+        }
+
+        public String getOwner() {
+            return owner;
+        }
+
+        public String getRepository() {
+            return repository;
+        }
+
+        public String getBranch() {
+            return branch;
+        }
+
+        public String getPath() {
+            return path;
+        }
+
+        public String getToken() {
+            return token;
+        }
+
+        public String getCommitMessage() {
+            return commitMessage;
+        }
+    }
+
+    /**
+     * Outcome of a publishing attempt.
+     */
+    public static class PublishResult {
+        private final boolean success;
+        private final boolean updated;
+        private final int statusCode;
+        private final String errorMessage;
+
+        private PublishResult(boolean success, boolean updated, int statusCode, String errorMessage) {
+            this.success = success;
+            this.updated = updated;
+            this.statusCode = statusCode;
+            this.errorMessage = errorMessage;
+        }
+
+        public static PublishResult success(boolean updated, int statusCode) {
+            return new PublishResult(true, updated, statusCode, null);
+        }
+
+        public static PublishResult failure(int statusCode, String message) {
+            return new PublishResult(false, false, statusCode, message);
+        }
+
+        public boolean isSuccess() {
+            return success;
+        }
+
+        public boolean isUpdated() {
+            return updated;
+        }
+
+        public int getStatusCode() {
+            return statusCode;
+        }
+
+        public String getErrorMessage() {
+            return errorMessage;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add a Markdown formatter for documents to share metadata and content in GitHub repositories
- introduce a GitHub publisher that uploads or updates files using the REST API
- extend the console UI so documents can be published directly to GitHub from the menu

## Testing
- `mvn -q test` *(fails: unable to download maven-resources-plugin due to HTTP 403)*

------
https://chatgpt.com/codex/tasks/task_e_68de8f94974083289756ea0e0d28460e